### PR TITLE
chore(release): Reset version to 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ by adding `commitlint` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:commitlint, "~> 0.1.3", runtime: false, only: :dev}
+    {:commitlint, "~> 0.1.0", runtime: false, only: :dev}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Commitlint.MixProject do
   def project do
     [
       app: :commitlint,
-      version: "0.1.3",
+      version: "0.1.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
This was decided because initial tags actually contained version that were not functional, testing out CI and Hex publish feature. The version `0.1.0` will now point to a valid version.